### PR TITLE
test: dispose color picker with editor

### DIFF
--- a/packages/build/src/build-static.ts
+++ b/packages/build/src/build-static.ts
@@ -29,7 +29,7 @@ const remoteUrl = getRemoteUrl(workerPath)
 const occurrence = `// const colorPickerWorkerUrl = \`\${assetDir}/packages/color-picker-worker/dist/colorPickerWorkerMain.js\`
 const colorPickerWorkerUrl = \`${remoteUrl}\``
 const replacement = `const colorPickerWorkerUrl = \`\${assetDir}/packages/color-picker-worker/dist/colorPickerWorkerMain.js\``
-if (!content.includes(occurrence)) {
+if (!content.includes(occurrence) && !content.includes(replacement)) {
   throw new Error('occurrence not found')
 }
 const newContent = content.replace(occurrence, replacement)

--- a/packages/e2e/src/color-picker.close-editor.ts
+++ b/packages/e2e/src/color-picker.close-editor.ts
@@ -1,0 +1,21 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'color-picker.close-editor'
+
+export const skip = 1
+
+export const test: Test = async ({ Editor, expect, FileSystem, Locator, Main }) => {
+  // arrange
+  const tmpDir = await FileSystem.getTmpDir()
+  await FileSystem.writeFile(`${tmpDir}/file.txt`, 'abc')
+  await Main.openUri(`${tmpDir}/file.txt`)
+  await Editor.openColorPicker()
+  const colorPicker = Locator('.ColorPicker')
+  await expect(colorPicker).toBeVisible()
+
+  // act
+  await Main.closeActiveEditor()
+
+  // assert
+  await expect(colorPicker).toBeHidden()
+}


### PR DESCRIPTION
Add an e2e regression that opens the color picker, closes the active editor, and asserts that the color picker is removed.

The test is temporarily skipped until the automated server 0.91.6 dependency update lands. Also make the static worker URL rewrite idempotent for the newer server output.