### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   {
     ignores: ['**/server/**', '**/memory/**'],
@@ -10,6 +11,12 @@ export default [
   {
     rules: {
       '@cspell/spellchecker': 'off',
+    },
+  },
+  {
+    files: ['**/test/**/*.ts'],
+    rules: {
+      'virtual-dom/prefer-merge-class-names': 'off',
     },
   },
 ]

--- a/packages/color-picker-worker/src/parts/AriaRoles/AriaRoles.ts
+++ b/packages/color-picker-worker/src/parts/AriaRoles/AriaRoles.ts
@@ -1,0 +1,4 @@
+import { AriaRoles } from '@lvce-editor/virtual-dom-worker'
+
+export const { Button } = AriaRoles
+export const Slider = 'slider'

--- a/packages/color-picker-worker/src/parts/GetColorPickerBottomVirtualDom/GetColorPickerBottomVirtualDom.ts
+++ b/packages/color-picker-worker/src/parts/GetColorPickerBottomVirtualDom/GetColorPickerBottomVirtualDom.ts
@@ -1,9 +1,11 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import { getColorPickerSliderThumbVirtualDom } from '../GetColorPickerSliderThumbVirtualDom/GetColorPickerSliderThumbVirtualDom.ts'
 import { getColorPickerSliderVirtualDom } from '../GetColorPickerSliderVirtualDom/GetColorPickerSliderVirtualDom.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 export const getColorPickerBottomVirtualDom = (): readonly VirtualDomNode[] => {
   return [
@@ -17,8 +19,8 @@ export const getColorPickerBottomVirtualDom = (): readonly VirtualDomNode[] => {
       childCount: 1,
       className: ClassNames.ColorPickerSliderWrapper,
       onPointerDown: DomEventListenerFunctions.HandleSliderPointerDown,
-      role: 'slider',
-      tabIndex: 0,
+      role: AriaRoles.Slider,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Div,
     },
     ...getColorPickerSliderVirtualDom(),

--- a/packages/color-picker-worker/src/parts/GetColorPickerVirtualDom/GetColorPickerVirtualDom.ts
+++ b/packages/color-picker-worker/src/parts/GetColorPickerVirtualDom/GetColorPickerVirtualDom.ts
@@ -1,6 +1,7 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import type { ColorPickerState } from '../ColorPickerState/ColorPickerState.ts'
+import * as AriaRoles from '../AriaRoles/AriaRoles.ts'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
 import * as DomEventListenerFunctions from '../DomEventListenerFunctions/DomEventListenerFunctions.ts'
 import { getColorPickerBottomVirtualDom } from '../GetColorPickerBottomVirtualDom/GetColorPickerBottomVirtualDom.ts'
@@ -18,16 +19,18 @@ const closeButtonNode: VirtualDomNode = {
   childCount: 0,
   className: ClassNames.ColorPickerCloseButton,
   onClick: DomEventListenerFunctions.HandleCloseButton,
+  role: AriaRoles.Button,
   type: VirtualDomElements.Div,
 }
 
 export const getColorPickerVirtualDom = (state: ColorPickerState): readonly VirtualDomNode[] => {
+  const { closeButtonEnabled } = state
   const nodes: VirtualDomNode[] = [
     parentNode,
     ...GetColorPickerRectangleVirtualDom.getColorPickerRectangleVirtualDom(),
     ...getColorPickerBottomVirtualDom(),
   ]
-  if (state.closeButtonEnabled) {
+  if (closeButtonEnabled) {
     nodes.push(closeButtonNode)
   }
   return nodes

--- a/packages/color-picker-worker/src/parts/TabIndex/TabIndex.ts
+++ b/packages/color-picker-worker/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0

--- a/packages/color-picker-worker/test/GetColorPickerVirtualDom.test.ts
+++ b/packages/color-picker-worker/test/GetColorPickerVirtualDom.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from '@jest/globals'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
+import * as AriaRoles from '../src/parts/AriaRoles/AriaRoles.ts'
 import * as CreateDefaultState from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as GetColorPickerVirtualDom from '../src/parts/GetColorPickerVirtualDom/GetColorPickerVirtualDom.ts'
+import * as TabIndex from '../src/parts/TabIndex/TabIndex.ts'
 
 test('getColorPickerVirtualDom', () => {
   const state = CreateDefaultState.createDefaultState()
@@ -36,15 +38,15 @@ test('getColorPickerVirtualDom', () => {
     {
       childCount: 2,
       className: 'ColorPickerBottom',
-      type: 4,
+      type: VirtualDomElements.Div,
     },
     {
       childCount: 1,
       className: 'ColorPickerSliderWrapper',
       onPointerDown: 1,
-      role: 'slider',
-      tabIndex: 0,
-      type: 4,
+      role: AriaRoles.Slider,
+      tabIndex: TabIndex.Focusable,
+      type: VirtualDomElements.Div,
     },
     {
       childCount: 0,

--- a/packages/color-picker-worker/test/SetRelativeX.test.ts
+++ b/packages/color-picker-worker/test/SetRelativeX.test.ts
@@ -23,8 +23,9 @@ test('setRelativeX clamps values within min and max bounds', () => {
     max: 100,
     min: 0,
   }
-  const tooLargeX = state.max + 100
-  const tooSmallX = state.min - 100
+  const { max, min } = state
+  const tooLargeX = max + 100
+  const tooSmallX = min - 100
 
   const resultLarge = setRelativeX(state, tooLargeX)
   const resultSmall = setRelativeX(state, tooSmallX)


### PR DESCRIPTION
Enable the shared `recommendedVirtualDom` ESLint preset and address its findings.

- use named ARIA role and tab-index constants
- give the clickable close control an explicit button role
- destructure render state and update focused test expectations
- keep the test-only class-name expectation exception scoped to tests