### PR TITLE
feature: hoist static virtual dom nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "devDependencies": {
         "@lerna/legacy-package-management": "^8.2.4",
-        "@lvce-editor/eslint-config": "^16.4.0",
+        "@lvce-editor/eslint-config": "^17.0.2",
         "eslint": "^10.7.0",
         "lerna": "^8.2.4",
         "prettier": "^3.9.5",
@@ -1701,9 +1701,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-16.4.0.tgz",
-      "integrity": "sha512-vc382ImEo+upv9LR+kr0vSpfyV8BBxKb+m2nCBVXjGm7eu5Cw9zTPv9X+mxOjWiNkUyWfuwY+NgbgsSC4Scu8g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-17.0.2.tgz",
+      "integrity": "sha512-wV4LFkEMVQ1/uYhHWZSA/W13cvACrp1z0BA0pjkuOZQhG3fIjeBC8+Tja22qbWgDPDcYaNi7we1T3hF8Wud5Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1713,14 +1713,14 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "16.4.0",
-        "@lvce-editor/eslint-plugin-e2e": "16.4.0",
-        "@lvce-editor/eslint-plugin-github-actions": "16.4.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "16.4.0",
-        "@lvce-editor/eslint-plugin-regex": "16.4.0",
-        "@lvce-editor/eslint-plugin-rpc": "16.4.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "16.4.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "16.4.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "17.0.2",
+        "@lvce-editor/eslint-plugin-e2e": "17.0.2",
+        "@lvce-editor/eslint-plugin-github-actions": "17.0.2",
+        "@lvce-editor/eslint-plugin-nvmrc": "17.0.2",
+        "@lvce-editor/eslint-plugin-regex": "17.0.2",
+        "@lvce-editor/eslint-plugin-rpc": "17.0.2",
+        "@lvce-editor/eslint-plugin-tsconfig": "17.0.2",
+        "@lvce-editor/eslint-plugin-virtual-dom": "17.0.2",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -1735,9 +1735,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-16.4.0.tgz",
-      "integrity": "sha512-KWAhBTB5GZrgFoL16rYvY6QI+MHUd5kQ++uFWpV8WE2/pF4RI2xiOTft7lfWUD+EARG9ygyRFbgtVO0RFlFOQw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-17.0.2.tgz",
+      "integrity": "sha512-ZWiYG7r/jNIcQBvzUGjatkzkfNCv6osL3UXZpIvEHJbzT3TsfzqQtu1qJ6K3affARi/NPNDVah4XSc3A/aMVsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1745,16 +1745,16 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-16.4.0.tgz",
-      "integrity": "sha512-kS1IGkvUeOZeVUGs+fxSOzGqqXRwWL1dZq1Kq0KHo24gNZ/WqKi2cLVWpAAyQZA+P0dp82SG7WwZ+NZHhPYoSA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-17.0.2.tgz",
+      "integrity": "sha512-aWlcQzoeAXHAc4RBwqJTHmcz+w+0Ozi6JJLCoZ5p9l4kUUMhzL7AELFF6bV+DTskKu0f20nFEcU4d0gc6buU0w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-16.4.0.tgz",
-      "integrity": "sha512-T66LFDS0nX3/H5nxFiNIkUMEou55FlOxLgOfkbCivZdQQ+fTZnNYb1zOdkxk9hKzQC6RaO4Oj0soilT02TDOQQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-17.0.2.tgz",
+      "integrity": "sha512-VEmxQxt+6WKTT5EH0u/bv9wlOWiBr+2467WaJqxywCjSglAcLCyIPhoEfnpfRMdR5B69iJhwBCqNl/h/luL9Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1763,9 +1763,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-16.4.0.tgz",
-      "integrity": "sha512-/vx42EiKdt8E7oJ+pbTTKC+V9tgO7yiLKnHlXi664A/s4rEQOfJbB9wq4HYY2hmsDymGokKcNCJNOrdE8GwszA==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-17.0.2.tgz",
+      "integrity": "sha512-e6EWbhYCNGZkhNOvt3+0poJbD2wbG2SjnP8N6SwxnHoUkLDM3lhFsayVW2sYhI7Zi5k6xw6AIiO5gmqQu12uNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1786,23 +1786,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-16.4.0.tgz",
-      "integrity": "sha512-XOVlNT6inumz2GLe70A5yuqRvEhGtXe2aCwtCuAnbkD5d1HH5G5NwSA374sF6Z+Kiy02s23eVfxOk+0oh2yQ6g==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-17.0.2.tgz",
+      "integrity": "sha512-S0NOHXqK4euhmZOdYXSaMr/LpbUzSoSaUZOC9m/UatykY3sfdA+v1f/7wnz2jyhykznihjfmF7aUp49+MGTiEA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-16.4.0.tgz",
-      "integrity": "sha512-ghI9uGpUyxPnJnVgKojf0RWTxGnNdmPz/JS4GdvHhw+Kl0cC2OQmvOKLDTSV423hj4WjaUBDqfdeAIZVMq0vLg==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-17.0.2.tgz",
+      "integrity": "sha512-ZYeIgvyNe3oso4fI//jpEpgbQ7FGqBGpjoTjVx03M9ra4FKQ4RBiP9RwpYu/kqNkIocZc1KgPQrBxSuh0khcMA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-16.4.0.tgz",
-      "integrity": "sha512-tVzMUV7vVy3H6M5kCgDxnL8EXRvDic0+GUb6fmzdsemU/HkA+zlKDbvKs9bfI79hX3EWeptFN2GOXnrGB84MbQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-17.0.2.tgz",
+      "integrity": "sha512-NjY4oo5aHjUiVFvBuuuo9uPr2/4r0dyztAWl8Nef+8GHwW5xftEsILEkjZI76V0EwU4QJyG0v9hVxPX2P4/5uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1810,9 +1810,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-16.4.0.tgz",
-      "integrity": "sha512-h0QVBtyzs0/ICLIDBDB1DFzmdvyCHfJB/AFxaonFJ7f6PIrUEFz/HjxvX8jMhcCllRxUrslWqF6DC9Gs76isVw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-17.0.2.tgz",
+      "integrity": "sha512-BOVb8oG/ZnYU4PxAu0l40F2Au2uGffoH31L3zffTfSVCNtmWj1uPzQ+mRZodxTdlvkLJrXRmmHBPIG8NpkDleA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@lerna/legacy-package-management": "^8.2.4",
-    "@lvce-editor/eslint-config": "^16.4.0",
+    "@lvce-editor/eslint-config": "^17.0.2",
     "eslint": "^10.7.0",
     "lerna": "^8.2.4",
     "prettier": "^3.9.5",

--- a/packages/color-picker-worker/src/parts/GetColorPickerBottomVirtualDom/GetColorPickerBottomVirtualDom.ts
+++ b/packages/color-picker-worker/src/parts/GetColorPickerBottomVirtualDom/GetColorPickerBottomVirtualDom.ts
@@ -7,23 +7,22 @@ import { getColorPickerSliderThumbVirtualDom } from '../GetColorPickerSliderThum
 import { getColorPickerSliderVirtualDom } from '../GetColorPickerSliderVirtualDom/GetColorPickerSliderVirtualDom.ts'
 import * as TabIndex from '../TabIndex/TabIndex.ts'
 
+const colorPickerBottomNode: VirtualDomNode = {
+  childCount: 2,
+  className: 'ColorPickerBottom',
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerSliderWrapperNode: VirtualDomNode = {
+  // TODO add ariavaluemin, ariavaluemax, ariavaluenow
+  childCount: 1,
+  className: ClassNames.ColorPickerSliderWrapper,
+  onPointerDown: DomEventListenerFunctions.HandleSliderPointerDown,
+  role: AriaRoles.Slider,
+  tabIndex: TabIndex.Focusable,
+  type: VirtualDomElements.Div,
+}
+
 export const getColorPickerBottomVirtualDom = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 2,
-      className: 'ColorPickerBottom',
-      type: VirtualDomElements.Div,
-    },
-    {
-      // TODO add ariavaluemin, ariavaluemax, ariavaluenow
-      childCount: 1,
-      className: ClassNames.ColorPickerSliderWrapper,
-      onPointerDown: DomEventListenerFunctions.HandleSliderPointerDown,
-      role: AriaRoles.Slider,
-      tabIndex: TabIndex.Focusable,
-      type: VirtualDomElements.Div,
-    },
-    ...getColorPickerSliderVirtualDom(),
-    ...getColorPickerSliderThumbVirtualDom(),
-  ]
+  return [colorPickerBottomNode, colorPickerSliderWrapperNode, ...getColorPickerSliderVirtualDom(), ...getColorPickerSliderThumbVirtualDom()]
 }

--- a/packages/color-picker-worker/src/parts/GetColorPickerRectangleVirtualDom/GetColorPickerRectangleVirtualDom.ts
+++ b/packages/color-picker-worker/src/parts/GetColorPickerRectangleVirtualDom/GetColorPickerRectangleVirtualDom.ts
@@ -1,27 +1,31 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+
+const colorPickerRectangleNode: VirtualDomNode = {
+  childCount: 3,
+  className: ClassNames.ColorPickerRectangle,
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerBackgroundColorNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerBackgroundColor,
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerLightNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerLight,
+  type: VirtualDomElements.Div,
+}
+
+const colorPickerDarkNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerDark,
+  type: VirtualDomElements.Div,
+}
+
 export const getColorPickerRectangleVirtualDom = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 3,
-      className: ClassNames.ColorPickerRectangle,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerBackgroundColor,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerLight,
-      type: VirtualDomElements.Div,
-    },
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerDark,
-      type: VirtualDomElements.Div,
-    },
-  ]
+  return [colorPickerRectangleNode, colorPickerBackgroundColorNode, colorPickerLightNode, colorPickerDarkNode]
 }

--- a/packages/color-picker-worker/src/parts/GetColorPickerSliderThumbVirtualDom/GetColorPickerSliderThumbVirtualDom.ts
+++ b/packages/color-picker-worker/src/parts/GetColorPickerSliderThumbVirtualDom/GetColorPickerSliderThumbVirtualDom.ts
@@ -1,12 +1,13 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+
+const colorPickerSliderThumbNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerSliderThumb,
+  type: VirtualDomElements.Div,
+}
+
 export const getColorPickerSliderThumbVirtualDom = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerSliderThumb,
-      type: VirtualDomElements.Div,
-    },
-  ]
+  return [colorPickerSliderThumbNode]
 }

--- a/packages/color-picker-worker/src/parts/GetColorPickerSliderVirtualDom/GetColorPickerSliderVirtualDom.ts
+++ b/packages/color-picker-worker/src/parts/GetColorPickerSliderVirtualDom/GetColorPickerSliderVirtualDom.ts
@@ -1,12 +1,13 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
 import { VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as ClassNames from '../ClassNames/ClassNames.ts'
+
+const colorPickerSliderNode: VirtualDomNode = {
+  childCount: 0,
+  className: ClassNames.ColorPickerSlider,
+  type: VirtualDomElements.Div,
+}
+
 export const getColorPickerSliderVirtualDom = (): readonly VirtualDomNode[] => {
-  return [
-    {
-      childCount: 0,
-      className: ClassNames.ColorPickerSlider,
-      type: VirtualDomElements.Div,
-    },
-  ]
+  return [colorPickerSliderNode]
 }


### PR DESCRIPTION
Updates ESLint and @lvce-editor/eslint-config to the latest releases and hoists the static color-picker virtual DOM nodes to module scope.