### PR TITLE
fix: account for hoisted node memory

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 425_000
+export const threshold = 430_000
 
 export const workerPath = join(root, '.tmp/dist/dist/colorPickerWorkerMain.js')
 


### PR DESCRIPTION
Raise the retained-heap budget slightly to account for the static virtual DOM nodes intentionally retained by the new hoisting rule.